### PR TITLE
Support fetch aliases for service with version

### DIFF
--- a/index.js
+++ b/index.js
@@ -377,10 +377,15 @@ module.exports = {
             this.buildActionRouteStructFromAliases(route, routes);
           }
 
+          let service = node.name;
           // resolve paths with auto aliases
           const hasAutoAliases = node.settings.routes.some(route => route.autoAliases);
           if (hasAutoAliases) {
-            const autoAliases = await this.fetchAliasesForService(node.name);
+            // suport services that has version, like v1.api
+            if (Object.prototype.hasOwnProperty.call(node, "version") && node.version !== undefined) {
+              service = `v${node.version}.` + service;
+            }
+            const autoAliases = await this.fetchAliasesForService(service);
             const convertedRoute = this.convertAutoAliasesToRoute(autoAliases);
             this.buildActionRouteStructFromAliases(convertedRoute, routes);
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moleculer-auto-openapi",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "moleculer-auto-openapi",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "swagger-ui-dist": "^4.1.3"


### PR DESCRIPTION
Some services could have a version property like this :
```
module.exports = {
    name: "api",
    version: 1,
   ...
}
``` 
so in `fetchAliasesForService` method it should be :
`this.broker.call('v1.api.listAliases')` instead of `this.broker.call('api.listAliases')`