### PR TITLE
Fix for NATS payload size #15

### DIFF
--- a/index.js
+++ b/index.js
@@ -274,7 +274,7 @@ module.exports = {
           ctx.meta.$responseType = "application/octet-stream";
         }
 
-        return fs.readFileSync(`${swaggerUiAssetPath}/${ctx.params.file}`);
+        return fs.createReadStream(`${swaggerUiAssetPath}/${ctx.params.file}`);
       }
     },
     ui: {

--- a/test/openapi.mixin.spec.js
+++ b/test/openapi.mixin.spec.js
@@ -5,6 +5,8 @@ const ApiGateway = require("moleculer-web");
 
 const Openapi = require("../index");
 
+const fs = require("fs");
+
 const OpenapiService = {
   mixins: [Openapi],
   settings: {
@@ -261,5 +263,23 @@ describe("Test 'openapi' mixin", () => {
     // check json https://editor.swagger.io/
     //console.log(JSON.stringify(json, null, ""));
     expect(json).toMatchObject(expectedSchema);
+  });
+
+  it("Asset is returned as a stream", async () => {
+    const file = "swagger-ui-bundle.js.map";
+    const path = require("swagger-ui-dist").getAbsoluteFSPath();
+    
+    const stream = await broker.call("openapi.assets", { file });
+
+    const expected = fs.readFileSync(`${path}/${file}`).toString();
+    
+    let buffer = "";
+    i = 0;
+    for await (const chunk of stream) {
+      buffer += chunk;
+    }
+
+    expect(stream).toBeInstanceOf(fs.ReadStream);
+    expect(buffer).toEqual(expected);
   });
 });


### PR DESCRIPTION
Changes `assets` action to return a `fs.ReadStream` instead of a `fs.Buffer` so that when using NATS or another transporter, messages are kept to a reasonable size.  moleculer-web handles stream responses appropriately.