### PR TITLE
Fix: TypeError with shortDefinition.split

### DIFF
--- a/index.js
+++ b/index.js
@@ -977,6 +977,10 @@ module.exports = {
         type: "string",
       };
 
+      if (typeof shortDefinition !== 'string') {
+        return node;
+      }
+
       let params = shortDefinition.split('|');
       params = params.map(v => v.trim());
 


### PR DESCRIPTION
### Description

This Pull Request fixes a `TypeError` that occurs when the `.split` method is called on the `shortDefinition` field, which is not of the expected string type.

**Error Details:**
```json
{
  "name": "TypeError",
  "message": "shortDefinition.split is not a function",
  "code": 500
}
```
**Fixes Implemented:**
	•	Added a type check for shortDefinition to ensure it’s a string before calling .split.
	•	Updated the relevant logic to handle non-string values appropriately.

**Linked Issue:**
Fixes #27