### PR TITLE
fix: allow specifing alternative property to get params schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,8 @@ module.exports = {
     assetsPath: "/api/openapi/assets",
     // names of moleculer-web services which contains urls, by default - all
     collectOnlyFromWebServices: [],
+    // attribute name to use for getting params schema from actions (default: 'params')
+    paramsAttribute: "params",
     commonPathItemObjectResponses: {
       200: {
         $ref: "#/components/responses/ReturnedData",
@@ -352,13 +354,14 @@ module.exports = {
       return doc;
     },
     attachParamsAndOpenapiFromEveryActionToRoutes(routes, nodes) {
+      const paramsAttr = this.settings.paramsAttribute;
       for (const routeAction in routes) {
         for (const node of nodes) {
           for (const nodeAction in node.actions) {
             if (routeAction === nodeAction) {
               const actionProps = node.actions[nodeAction];
 
-              routes[routeAction].params = actionProps.params || {};
+              routes[routeAction].params = actionProps[paramsAttr] || {};
               routes[routeAction].openapi = actionProps.openapi || null;
               break;
             }
@@ -976,6 +979,10 @@ module.exports = {
       const node = {
         type: "string",
       };
+
+      if (typeof shortDefinition !== 'string') {
+        return node;
+      }
 
       let params = shortDefinition.split('|');
       params = params.map(v => v.trim());


### PR DESCRIPTION
We are using moleculer together with the zod based param validator.
Additionaly we want to leverage moleculer-auto-openapi for auto generated openapi schemas.
problem is, the package currently cannot handle zod schemas.

In order to workaround this issue, this PR adds the option to set a different property to use for getting the params schema.|
This allows for using any params validator together with this library as long as you are able to generate matching schemas (fastest validator schema) based on it and attach it to a different property.

this fork is already used in our production system and works well and stable.